### PR TITLE
BUG: Jupyter Plotly config Windows compatibility

### DIFF
--- a/c3dev/devconfig.py
+++ b/c3dev/devconfig.py
@@ -8,7 +8,10 @@ from .util import exec_command
 
 
 def config_jupyter_plotly():
-    environ = "NODE_OPTIONS=--max-old-space-size=4096"
+    if not sys.platform == "win32":
+        environ = "NODE_OPTIONS=--max-old-space-size=4096"
+    else:
+        environ = ""
     installs = [
         "@jupyter-widgets/jupyterlab-manager",
         "plotlywidget",


### PR DESCRIPTION
With this change, you can run "c3dev_config . ../cogent3" on Windows without fail.