### PR TITLE
Implement scriv in the toolchain

### DIFF
--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,76 @@
+# Adding changelog entries
+This directory is used to store changelog fragments for the next release
+of the project.  Each file should contain a small changelog fragment
+that will be added to the full changelog when the release is made.
+The file is created using 
+```
+scriv create --edit
+``` 
+to create a change entry 
+
+This will create a file with the correct name and format and commented out sample categories, and load it into your .git editor (the one specified by ```git config --global core.editor``` )
+
+Uncomment the category of change you are making and add a short description of the
+change as a markdown bullet point.  For example:
+
+Contributors
+  * khiron
+
+ENH
+  * Added a new feature that allows users to do Y
+
+DEP
+  * Removed deprecated feature Z
+
+BUG
+  * Fixed a bug that caused the project to crash when a user did X
+    by doing Y instead
+
+DOC
+  * Documented feature Z
+
+Check the file in with your changes.  
+
+---
+# Building a changelog
+
+To build the changelog for the next release, run 
+
+```
+scriv collect 
+```
+
+This will create a file called CHANGELOG.md in the root of the project.  This file will contain the full changelog for the project, including all the fragments that have been added to the changelog.d directory and remove those fragments.  Note this requires that the Setup.py file's __version__ variable is updated from the last time you ran collect, otherwise you will get a warning  
+
+```
+Entry 'Changes since release 0.0.1' already uses version '0.0.1'.
+```
+... and the fragments will not be collected. When the __version__ variable in the project is updated the next time you run collect, the fragments will be collected and the changelog will be updated.
+
+You can override this to create a new collection of all available fragments that are not aligned with a __version__ with 
+
+```
+scriv collect  --version "description of a milestone not yet used"
+```
+
+---
+# Releasing a new version
+To release a version of the project, run 
+
+```
+scriv release
+```
+
+This will create a new tag in the git repository, and create a new release on github.  The release will contain the full changelog for the project, and the tag will be annotated with the full changelog as well.  Note you will need to have a github classic personal access token set up in your environment (GITHUB_TOKEN) for this to work. 
+
+If you are using VS code and powershell you can add the following to your settings.json file to set the environment variable for the terminal.  If you are using a different terminal you will need to set the environment variable in the appropriate way for your terminal.
+
+```json
+
+"terminal.integrated.env.windows": {
+
+        "GITHUB_TOKEN": "ghp_...",
+    }
+```
+
+---

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,8 @@
+[scriv]
+format=md
+categories=Contributers,ENH,BUG,DOC, Deprecations,Discontinued
+output_file=changelog.md
+version=literal: setup.py:__version__
+skip_fragments=README.*
+new_fragment_template=file: changelog.d/templates/new.md.j2
+entry_title_template=file: changelog.d/templates/title.md.j2

--- a/changelog.d/templates/new.md.j2
+++ b/changelog.d/templates/new.md.j2
@@ -1,0 +1,17 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+{% for cat in config.categories -%}
+<!--
+### {{ cat }}
+
+- A bullet item for the {{ cat }} category.
+
+-->
+{% endfor -%}
+
+
+

--- a/changelog.d/templates/new.rst.j2
+++ b/changelog.d/templates/new.rst.j2
@@ -1,0 +1,15 @@
+.. A new scriv changelog fragment.
+{% if config.categories -%}
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+{% for cat in config.categories -%}
+.. {{ cat }}
+.. {{ config.rst_header_chars[1] * (cat|length) }}
+..
+.. - A bullet item for the {{ cat }} category.
+..
+{% endfor -%}
+{% else %}
+- A bullet item for this fragment. EDIT ME!
+{% endif -%}

--- a/changelog.d/templates/title.md.j2
+++ b/changelog.d/templates/title.md.j2
@@ -1,0 +1,1 @@
+Changes since release {{version}}

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,7 @@
+
+<a id='changelog-0.1'></a>
+# Changes since release 0.1
+
+## ENH
+
+- Added scriv to tool chain

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
     packages=["c3dev"],
     install_requires=[
         "click",
+        "scriv",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
Changelog management.

Need an issue in cogent 

This implementation in c3dev uses an .ini file in the changelog.d directory to configure scriv.  In cogent configuration would be managed with pyproject.toml

