### PR TITLE
Docker containers for development and profiling containers

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -14,7 +14,7 @@ Build a docker image in your repository from c3dev.DockerFile in this folder and
 
 To run a docker container for development, you need to mount the root directory of the clone of your fork of the cogent3 repository into the container, and also mount your ssh key (saved to `$env:USERPROFILE/.ssh/github`) for accessing that fork into the container.
 
-The following assumes your current directory is the root directory of your clone of the cogent3 repository.  If not you can replace the {PWD} macro with the path to the root directory of your clone of the cogent3 repository.
+The following sample command for a bash terminal shell assumes your current directory is the root directory of your clone of the cogent3 repository.  If not you can replace the {PWD} macro with the path to the root directory of your clone of the cogent3 repository.
 
 ```sh
     docker run -it --rm -v ${PWD}:/cogent3 c3dev -v $env:USERPROFILE/.ssh/github:/root/.ssh/id_rsa -p 3000:3000 --name cogent3dev c3dev /bin/bash
@@ -24,20 +24,16 @@ Note: This will also set up port mapping of port 3000 so that you attach to the 
 
 ## Build a docker image for profiling cogent3 in a container on your docker host
 
-You have to first have built a docker image for development as described above, as the profile image is built from the development image.
-
-Build a docker image in your repository from c3prof.DockerFile in this folder and name it c3prof (with the tag command) as follows.  Note the current directory should be the one that contains the c3dev.DockerFile and c3prof.DockerFile configuration files and the entrypoint.sh script.  If not replace the final . with the path to the directory that contains those files.
+This container has the latest version of cogent3 installed in it, and is configured to run pytest profiler and send the results to a direcctory in the container that you will mount to a path in your host OS.  
 
 ```bash
-    docker build --tag c3prof -f docker/3prof.DockerFile . 
+    docker build --tag c3prof -f docker/c3prof.DockerFile .
 ```
 
 ## Running a docker container for profiling cogent3 in a container on your docker host
 
-To run a docker container for profiling cogent3 in a container on your docker host, you need to mount the root directory of the clone of your fork of the cogent3 repository into the container, and also mount your ssh key for accessing that fork into the container.
-
-The following assumes your current directory is the root directory of your clone of the cogent3 repository.  If not you can replace the {PWD} macro with the path to the root directory of your clone of the cogent3 repository.
+To run a docker container for profiling cogent3 in a container on your docker host, you need to mount a directory for the results of the profiling.  If the path on your docker host is /c3prof_results, then you can run the following command to run the profiling container.
 
 ```sh
-    docker run --rm -v ${PWD}:/cogent3 c3prof -v $env:USERPROFILE/.ssh/github:/root/.ssh/id_rsa --name cogent3prof c3prof 
+    docker run -it --rm -v /c3prof_results:/results c3prof 
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,43 @@
+# Developing Cogent3 in a docker container
+
+## install docker 
+
+## Build docker image for development
+
+Build a docker image in your repository from c3dev.DockerFile in this folder and name it c3dev (with the tag command).  Note the current directory should be the one that contains the c3dev.DockerFile configuration file and the entrypoint.sh script.  If not replace the final . with the path to the directory that contains those files.
+
+```bash
+    docker build --tag c3dev -f docker/c3dev.DockerFile . 
+```
+
+## Running a docker container for development
+
+To run a docker container for development, you need to mount the root directory of the clone of your fork of the cogent3 repository into the container, and also mount your ssh key (saved to `$env:USERPROFILE/.ssh/github`) for accessing that fork into the container.
+
+The following assumes your current directory is the root directory of your clone of the cogent3 repository.  If not you can replace the {PWD} macro with the path to the root directory of your clone of the cogent3 repository.
+
+```sh
+    docker run -it --rm -v ${PWD}:/cogent3 c3dev -v $env:USERPROFILE/.ssh/github:/root/.ssh/id_rsa -p 3000:3000 --name cogent3dev c3dev /bin/bash
+```
+
+Note: This will also set up port mapping of port 3000 so that you attach to the container with VS code  
+
+## Build a docker image for profiling cogent3 in a container on your docker host
+
+You have to first have built a docker image for development as described above, as the profile image is built from the development image.
+
+Build a docker image in your repository from c3prof.DockerFile in this folder and name it c3prof (with the tag command) as follows.  Note the current directory should be the one that contains the c3dev.DockerFile and c3prof.DockerFile configuration files and the entrypoint.sh script.  If not replace the final . with the path to the directory that contains those files.
+
+```bash
+    docker build --tag c3prof -f docker/3prof.DockerFile . 
+```
+
+## Running a docker container for profiling cogent3 in a container on your docker host
+
+To run a docker container for profiling cogent3 in a container on your docker host, you need to mount the root directory of the clone of your fork of the cogent3 repository into the container, and also mount your ssh key for accessing that fork into the container.
+
+The following assumes your current directory is the root directory of your clone of the cogent3 repository.  If not you can replace the {PWD} macro with the path to the root directory of your clone of the cogent3 repository.
+
+```sh
+    docker run --rm -v ${PWD}:/cogent3 c3prof -v $env:USERPROFILE/.ssh/github:/root/.ssh/id_rsa --name cogent3prof c3prof 
+```

--- a/docker/c3dev.DockerFile
+++ b/docker/c3dev.DockerFile
@@ -1,0 +1,42 @@
+# Use the official Debian image as the base image
+FROM debian:latest
+
+# Set environment variables to non-interactive so apt-get doesn't wait for prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    python3.11 \
+    python3-pip \
+    python3.11-venv \
+    openssh-client
+
+# Set the working directory
+WORKDIR /cogent3
+
+# Create a virtual environment named c3dev
+RUN python3.11 -m venv /c3dev
+
+# Activate the virtual environment; subsequent commands will use this environment
+ENV PATH="/c3dev/bin:$PATH"
+
+# Copy entrypoint script to pass keys from the host (specified in SSH_KEYS_SOURCE_DIR) to the container
+COPY docker/entrypoint.sh /entrypoint.sh
+
+# Set permissions for the entrypoint script
+RUN chmod +x /entrypoint.sh
+
+# Set the entrypoint
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Install zsh
+RUN apt-get install -y zsh
+
+# Install oh-my-zsh
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+
+# Optionally, set zsh as the default shell for the root user
+RUN chsh -s $(which zsh)
+
+# By default run an interactive shell when the container launches
+CMD ["/bin/zsh"]

--- a/docker/c3prof.DockerFile
+++ b/docker/c3prof.DockerFile
@@ -14,15 +14,17 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
+RUN git clone https://github.com/cogent3/cogent3.git /cogent3-repo
+
 # Set working directory
-WORKDIR /c3env/lib/python3.11/site-packages/cogent3
+WORKDIR /cogent3-repo
 
 # Create a Python virtual environment and activate it
 RUN python3.11 -m venv /c3env
 ENV PATH="/c3env/bin:$PATH"
 
 # Install cogent3 from GitHub
-RUN pip install "cogent3[dev]"
+RUN python -m pip install git+https://github.com/cogent3/cogent3.git@develop
 
 # Install pytest, pytest-profiling and other required Python packages
 RUN python -m pip install pytest pytest-profiling gprof2dot

--- a/docker/c3prof.DockerFile
+++ b/docker/c3prof.DockerFile
@@ -1,0 +1,31 @@
+# Use Debian as a base image
+FROM debian:latest
+
+# Set environment variables to ensure non-interactive installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies and Python
+RUN apt-get update && apt-get install -y \
+    python3.11 \
+    python3-pip \
+    python3.11-venv \
+    curl \
+    graphviz \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /c3env/lib/python3.11/site-packages/cogent3
+
+# Create a Python virtual environment and activate it
+RUN python3.11 -m venv /c3env
+ENV PATH="/c3env/bin:$PATH"
+
+# Install cogent3 from GitHub
+RUN pip install "cogent3[dev]"
+
+# Install pytest, pytest-profiling and other required Python packages
+RUN python -m pip install pytest pytest-profiling gprof2dot
+
+# Default command to run pytest with profiling
+CMD ["pytest", "--profile", "--profile-svg", "--pstats-dir=/results"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Set the path to the SSH private key
+SSH_PRIVATE_KEY=/root/.ssh/id_rsa
+
+# Check if the SSH private key file exists
+if [ -f "${SSH_PRIVATE_KEY}" ]; then
+    # Set permissions
+    chmod 600 "${SSH_PRIVATE_KEY}"
+    # make sure that agent is running and has the key
+    eval "$(ssh-agent -s)"
+    ssh-add /root/.ssh/id_rsa
+else
+    echo "No SSH private key found at: ${SSH_PRIVATE_KEY}"
+    echo "If you don't mount your SSH private key when you run the container, you won't be able to access private repositories on github."
+fi
+
+# Make sure we have the venv loaded
+source /c3dev/bin/activate
+
+# Install the local clone of cogent3
+python3 -m pip install /cogent3
+
+# Execute the main process
+exec "$@"


### PR DESCRIPTION
- docker/c3dev.DockerFile 
   - container for working with a local clone of your private fork of cogent3
   - maps local clone into the container
   - passes through GitHub credentials (using entrypoint.sh script)
   - maps ports for VS Code to attach to the container and run natively in the container
- docker/c3prof.DockerFile 
  - container that loads the develop branch of cogent3 and runs pytest with profiling